### PR TITLE
fix: will crash when first children w/o children

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ const remarkGithubAlerts: Plugin<RemarkGitHubAlertsOptions[], Root> = (
       const firstParagraph = children[0]
       if (!firstParagraph)
         return
-      let firstContent = firstParagraph.children[0]
+      let firstContent = firstParagraph.children?.[0]
       if (!firstContent)
         return
       if (

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,0 +1,43 @@
+/// <reference types="vite/client" />
+import dedent from 'dedent'
+import rehypeFormat from 'rehype-format'
+import rehypeStringify from 'rehype-stringify'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import { unified } from 'unified'
+import { describe, expect, it } from 'vitest'
+
+import remarkGithubAlerts from '../src'
+
+describe('Should process basic blockquote', () => {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGithubAlerts)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeFormat)
+    .use(rehypeStringify, { allowDangerousHtml: true })
+
+  it('process w/ code type children', async () => {
+    const result = await processor.process(dedent`
+      >     [component/folder touched]: Description intent of your changes
+      >
+      >     [List of changes]
+      >
+      >     Signed-off-by: Your Name your@email.com
+
+      For example:
+
+      >     swss-common: Stabilize the ConsumerTable
+      >
+      >     * Fixing autoreconf
+      >     * Fixing unit-tests by adding checkers and initialize the DB before start
+      >     * Adding the ability to select from multiple channels
+      >     * Health-Monitor - The idea of the patch is that if something went wrong with the notification channel,
+      >       we will have the option to know about it (Query the LLEN table length).
+      >
+      >       Signed-off-by: user@dev.null
+    `)
+
+    void expect(String(result)).toContain('blockquote')
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This processor will crash when the `blockquote`'s first children without children, just like

```md
>     [component/folder touched]: Description intent of your changes
>
>     [List of changes]
>
> 	  Signed-off-by: Your Name your@email.com

For example:

>     swss-common: Stabilize the ConsumerTable
>
>     * Fixing autoreconf
>     * Fixing unit-tests by adding checkers and initialize the DB before start
>     * Adding the ability to select from multiple channels
>     * Health-Monitor - The idea of the patch is that if something went wrong with the notification channel,
>       we will have the option to know about it (Query the LLEN table length).
>
>       Signed-off-by: user@dev.null
```

![image](https://github.com/user-attachments/assets/ae7b9628-1909-407a-bc04-e0e0fcddd479)


### Linked Issues


### Additional context

Any suggestion please feel free to comment

<!-- e.g. is there anything you'd like reviewers to focus on? -->
